### PR TITLE
Added dynamic repositioning of speech bubble when user changes size of window

### DIFF
--- a/js/joubel-speech-bubble.js
+++ b/js/joubel-speech-bubble.js
@@ -83,6 +83,34 @@ H5P.JoubelSpeechBubble = (function ($) {
       $currentSpeechBubble.addClass('show');
     }, 0);
 
+    position($currentSpeechBubble, $tail, $innerTail, $h5pContainer, $container, maxWidth);
+
+    // Handle click to close
+    H5P.$body.on('mousedown.speechBubble', handleOutsideClick);
+
+    $(window).resize(() => {
+      position($currentSpeechBubble, $tail, $innerTail, $h5pContainer, $container, maxWidth);
+    });
+
+    // Handle clicks when inside IV which blocks bubbling.
+    $container.parents('.h5p-dialog')
+      .on('mousedown.speechBubble', handleOutsideClick);
+
+    if (iDevice) {
+      H5P.$body.css('cursor', 'pointer');
+    }
+
+    return this;
+  }
+
+  // Remove speechbubble if it belongs to a dom element that is about to be hidden
+  H5P.externalDispatcher.on('domHidden', function (event) {
+    if ($currentSpeechBubble !== undefined && event.data.$dom.find($currentContainer).length !== 0) {
+      remove();
+    }
+  });
+
+  var position = function($currentSpeechBubble, $tail, $innerTail, $h5pContainer, $container, maxWidth) {
     // Calculate offset between the button and the h5p frame
     var offset = getOffsetBetween($h5pContainer, $container);
 
@@ -108,33 +136,14 @@ H5P.JoubelSpeechBubble = (function ($) {
     var preparedTailCSS = tailCSS(direction, tailPosition);
     $tail.css(preparedTailCSS);
     $innerTail.css(preparedTailCSS);
-
-    // Handle click to close
-    H5P.$body.on('mousedown.speechBubble', handleOutsideClick);
-
-    // Handle clicks when inside IV which blocks bubbling.
-    $container.parents('.h5p-dialog')
-      .on('mousedown.speechBubble', handleOutsideClick);
-
-    if (iDevice) {
-      H5P.$body.css('cursor', 'pointer');
-    }
-
-    return this;
   }
-
-  // Remove speechbubble if it belongs to a dom element that is about to be hidden
-  H5P.externalDispatcher.on('domHidden', function (event) {
-    if ($currentSpeechBubble !== undefined && event.data.$dom.find($currentContainer).length !== 0) {
-      remove();
-    }
-  });
 
   /**
    * Static function for removing the speechbubble
    */
   var remove = function() {
     H5P.$body.off('mousedown.speechBubble');
+    $(window).off('resize');
     $currentContainer.parents('.h5p-dialog').off('mousedown.speechBubble');
     if (iDevice) {
       H5P.$body.css('cursor', '');

--- a/js/joubel-speech-bubble.js
+++ b/js/joubel-speech-bubble.js
@@ -110,7 +110,16 @@ H5P.JoubelSpeechBubble = (function ($) {
     }
   });
 
-  var position = function($currentSpeechBubble, $tail, $innerTail, $h5pContainer, $container, maxWidth) {
+  /**
+   * Repositions the speechbubble according to the position of the container
+   * @param {object} $currentSpeechbubble the speech bubble that should be positioned
+   * @param {object} $tail the tail (the triangle that points to the referenced container)
+   * @param {object} $innerTail the inner tail (the triangle that points to the referenced container)
+   * @param {object} $h5pContainer the container of the whole h5p content type
+   * @param {object} $container the container to which the speech bubble should point 
+   * @param {number} maxWidth the maximum width of the speech bubble
+   */
+  function position($currentSpeechBubble, $tail, $innerTail, $h5pContainer, $container, maxWidth) {
     // Calculate offset between the button and the h5p frame
     var offset = getOffsetBetween($h5pContainer, $container);
 
@@ -254,7 +263,8 @@ H5P.JoubelSpeechBubble = (function ($) {
         width: width + 'px',
         bottom: position.bottom + 'px',
         left: position.left + 'px',
-        fontSize: fontSize + 'px'
+        fontSize: fontSize + 'px',
+        top: ''
       };
     }
     else {
@@ -262,7 +272,8 @@ H5P.JoubelSpeechBubble = (function ($) {
         width: width + 'px',
         top: position.top + 'px',
         left: position.left + 'px',
-        fontSize: fontSize + 'px'
+        fontSize: fontSize + 'px',
+        bottom: ''
       };
     }
   }
@@ -278,20 +289,22 @@ H5P.JoubelSpeechBubble = (function ($) {
     if (direction === 'top') {
       return {
         bottom: position.bottom + 'px',
-        left: position.left + 'px'
+        left: position.left + 'px',
+        top: ''
       };
     }
     else {
       return {
         top: position.top + 'px',
-        left: position.left + 'px'
+        left: position.left + 'px',
+        bottom: ''
       };
     }
   }
 
   /**
    * Calculates the offset between an element inside a container and the
-   * container. Only works if all the edges of the inner element is inside the
+   * container. Only works if all the edges of the inner element are inside the
    * outer element.
    * Width/height of the elements is included as a convenience.
    *


### PR DESCRIPTION
The current speech bubble does not change its position when users change the size of the window. The same is true when users change the orientation of their mobile devices. 

The code changes in this pull request subscribe to the 'resize' event of window and reposition the speech bubble. I've also turned some variables to private fields of H5P.JoubelSpeechBubble:   
```
$tail
$innerTail;
currentMaxWidth

```
This was necessary, as the repositioning code requires a reference to them and is called by a private method, which doesn't have access to the variables declared in the constructor.