### PR TITLE
HFP-3506 Remove hover tooltip from Joubel tooltip

### DIFF
--- a/css/joubel-tip.css
+++ b/css/joubel-tip.css
@@ -8,22 +8,6 @@
   color: #333;
 }
 
-.joubel-tip-container:hover:before {
-  content: attr(aria-label);
-
-  position: absolute;
-  left: 50%;
-  z-index: 5;
-
-  padding: 0.25em 0.75em;
-  background: #212121;
-  color: white;
-  white-space: nowrap;
-  line-height: 1.5;
-  box-shadow: 0 0 0.5em #858585;
-  transform: translate(-50%, -1.25em);
-}
-
 .joubel-tip-container:focus {
   outline: 0;
   box-shadow: 0px 0px 5px 2px rgba(140,185,240,1);


### PR DESCRIPTION
Currently, a lot of the content types are struggling with the positioning of the hover tooltip and are not displaying it properly. We need to refactor and get the click tooltip to use a proper hover tooltip.