### PR TITLE
Make scorebar progress unselectable

### DIFF
--- a/css/joubel-score-bar.css
+++ b/css/joubel-score-bar.css
@@ -45,6 +45,7 @@
   -o-transition: width 0.4s ease-in-out;
   transition: width 0.4s ease-in-out;
   -webkit-backface-visibility: hidden;
+  user-select: none;
 }
 /* The star */
 .h5p-joubelui-score-bar-star {


### PR DESCRIPTION
When merged in, prevents user selection of the score bar progress bar that would otherwise reveal the text score. See https://h5p.org/comment/48998