### PR TITLE
HFP-4294 Fix speech bubble not showing up

### DIFF
--- a/js/joubel-speech-bubble.js
+++ b/js/joubel-speech-bubble.js
@@ -118,9 +118,14 @@ H5P.JoubelSpeechBubble = (function ($) {
    * @return {object} the h5p container (jquery element)
    */
   function getH5PContainer($container) {
-    var $h5pContainer = $container.closest('.h5p-frame');
+    // If h5p.content(.h5p-iframe) was chosen in fullscreen mode, the speech bubble would not show.
+    let $h5pContainer = $container.closest('.h5p-container.h5p-fullscreen');
 
-    // Check closest h5p frame first, then check for container in case there is no frame.
+    if (!$h5pContainer.length) {
+      $h5pContainer = $container.closest('.h5p-frame');
+    }
+
+    // Check closest h5p frame next, then check for container in case there is no frame.
     if (!$h5pContainer.length) {
       $h5pContainer = $container.closest('.h5p-container');
     }


### PR DESCRIPTION
When merged in, when in fullscreen mode, will attach the JoubelUI speech bubble to `.h5p-container` instead of `.h5p-content` to make it show up when the content is embedded.